### PR TITLE
Https to http for kur.deepgram.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. |LICENSE| image:: https://img.shields.io/badge/license-Apache%202-blue.svg
    :target: https://github.com/deepgram/kur/blob/master/LICENSE
 .. |PYTHON| image:: https://img.shields.io/badge/python-3.4%2C3.5%2C3.6-lightgrey.svg
-   :target: https://kur.deepgram.com/installing.html
+   :target: http://kur.deepgram.com/installing.html
 .. |BUILD| image:: https://travis-ci.org/deepgram/kur.svg?branch=master
    :target: https://travis-ci.org/deepgram/kur
 .. |GITTER| image:: https://badges.gitter.im/deepgram-kur/Lobby.svg
@@ -18,7 +18,7 @@
 
 .. package_readme_starts_here
 
-.. _Tutorial: https://kur.deepgram.com/tutorial.html
+.. _Tutorial: http://kur.deepgram.com/tutorial.html
 
 ******************************
 Kur: Descriptive Deep Learning

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 .. |LICENSE| image:: https://img.shields.io/badge/license-Apache%202-blue.svg
    :target: https://github.com/deepgram/kur/blob/master/LICENSE
 .. |PYTHON| image:: https://img.shields.io/badge/python-3.4%2C3.5%2C3.6-lightgrey.svg
-   :target: https://kur.deepgram.com/installing.html
+   :target: http://kur.deepgram.com/installing.html
 .. |BUILD| image:: https://travis-ci.org/deepgram/kur.svg?branch=master
    :target: https://travis-ci.org/deepgram/kur
 .. |GITTER| image:: https://badges.gitter.im/deepgram-kur/Lobby.svg

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -17,7 +17,7 @@ When installing Kur, you may encounter this error::
                  Kur requires Python 3.4 or later.
             See our troubleshooting page to get started:
     
-     https://kur.deepgram.com/troubleshooting.html#installation
+     http://kur.deepgram.com/troubleshooting.html#installation
     
     ============================================================
     

--- a/kur/__init__.py
+++ b/kur/__init__.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__homepage__ = 'https://kur.deepgram.com'
+__homepage__ = 'http://kur.deepgram.com'
 from .version import __version__
 
 from . import utils

--- a/kur/model/hooks/plot_hook.py
+++ b/kur/model/hooks/plot_hook.py
@@ -48,7 +48,7 @@ class PlotHook(TrainingHook):
 		except:
 			logger.exception('Failed to import "matplotlib". Make sure it is '
 				'installed, and if you have continued trouble, please check '
-				'out our troubleshooting page: https://kur.deepgram.com/'
+				'out our troubleshooting page: http://kur.deepgram.com/'
 				'troubleshooting.html#plotting')
 			raise
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def error_message(msg):
 		'ERROR', '',
 		msg, ''
 		'See our troubleshooting page to get started:', '',
-		'https://kur.deepgram.com/troubleshooting.html#installation', '',
+		'http://kur.deepgram.com/troubleshooting.html#installation', '',
 		'='*line_width, '',
 		"Uh, oh. There was an error. Look up there ^^^^ and you'll be",
 		'training awesome models in no time!'


### PR DESCRIPTION
The kur.deepmind.com site doesn't support https, so the links from this page must use http.
In reference to https://github.com/deepgram/kur/issues/9