### PR TITLE
Add (experimental) multi-gpu to Kur.

### DIFF
--- a/kur/backend/backend.py
+++ b/kur/backend/backend.py
@@ -26,7 +26,7 @@ class Backend:
 	"""
 
 	###########################################################################
-	def __init__(self, variant=None, device=None):
+	def __init__(self, variant=None, device=None, parallel=None):
 		""" Create a new backend.
 
 			Part of this call should be to ensure that all the necessary
@@ -76,6 +76,8 @@ class Backend:
 			raise ValueError('Invalid device specification: {}. If a '
 				'device is explicitly specified, it must be "cpu", "gpu" '
 				'or "gpuX" where "X" is an integer.'.format(device))
+
+		self.parallel = parallel or 1
 
 		logger.info('Creating backend: %s', self.get_name())
 		logger.info('Backend variants: %s',

--- a/kur/backend/keras_backend.py
+++ b/kur/backend/keras_backend.py
@@ -533,6 +533,10 @@ class KerasBackend(Backend):
 				output=[node.value for node in model.outputs.values()]
 			)
 
+			if self.toolchain == 'tensorflow' and self.parallel > 1:
+				from ..utils.parallelism import make_parallel
+				compiled = make_parallel(compiled, self.parallel)
+
 			if logger.isEnabledFor(logging.DEBUG):
 				x = io.StringIO()
 				with contextlib.redirect_stdout(x):
@@ -586,10 +590,6 @@ class KerasBackend(Backend):
 			updates = optimizer.get_optimizer(self)(
 				compiled.trainable_weights, total_loss
 			)
-
-			if self.toolchain == 'tensorflow' and self.parallel > 1:
-				from ..utils.parallelism import make_parallel
-				compiled = make_parallel(compiled, self.parallel)
 
 			if not assemble_only:
 				func = K.function(

--- a/kur/backend/keras_backend.py
+++ b/kur/backend/keras_backend.py
@@ -658,7 +658,7 @@ class KerasBackend(Backend):
 
 		provider = BatchProvider(
 			sources=dict(zip(model.provider.keys, model.provider.sources)),
-			batch_size=2,
+			batch_size=2*self.parallel,
 			num_batches=1,
 			randomize=False
 		)

--- a/kur/utils/parallelism.py
+++ b/kur/utils/parallelism.py
@@ -71,13 +71,13 @@ def make_parallel(model, gpu_count):
 				# Save all the outputs for 
 				# merging back together later
 				for l in range(len(outputs)):
-					outputs_all[l].append(outputs[l])
+					all_outputs[l].append(outputs[l])
 
 	# Merge outputs on CPU
 	with tf.device('/cpu:0'):
 		merged = []
 
-		for outputs in outputs_all:
+		for outputs in all_outputs:
 			merged.append(merge(outputs, mode='concat', concat_axis=0))
 
 	return Model(input=model.inputs, output=merged)

--- a/kur/utils/parallelism.py
+++ b/kur/utils/parallelism.py
@@ -1,0 +1,83 @@
+"""
+Copyright 2017 Anthony Rousseau for Allo-media
+Based on kuza55 keras-extras (https://github.com/kuza55/keras-extras)
+and jonilaserson (https://github.com/fchollet/keras/issues/2436) code.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from keras.layers import merge
+from keras.layers.core import Lambda
+from keras.models import Model
+from keras import backend as K
+
+import tensorflow as tf
+
+
+def make_parallel(model, gpu_count):
+	""" Allows a model to run on multiple GPUs.
+	"""
+	def slice_batch(x, n_gpus, part):
+		""" Divide the input batch into [n_gpus] slices,
+			and obtain slice no. [part].
+			i.e. if len(x) = 10, then slice_batch(x, 2, 1)
+			will return x[5:].
+		"""
+		sh = K.shape(x)
+		L = sh[0] // n_gpus # sh[0] = batch_size
+
+		if part == n_gpus - 1:
+			return x[part*L:]
+
+		return x[part*L:(part+1)*L]
+
+	all_outputs = []
+
+	# Empty list for each output in the model
+	for i in range(len(model.outputs)):
+		all_outputs.append([])
+
+	# Place a copy of the model on each GPU, 
+	# each getting a slice of the batch
+	for i in range(gpu_count):
+		with tf.device('/gpu:%d' % i):
+			with tf.name_scope('tower_%d' % i) as scope:
+				inputs = []
+
+				# Slice each input into a piece 
+				# for processing on this GPU
+				for x in model.inputs:
+					input_shape = tuple(x.get_shape().as_list())[1:]
+					slice_n = Lambda(slice_batch, 
+						lambda shape: input_shape, 
+						arguments={'n_gpus':gpu_count, 'part':i})(x)
+					inputs.append(slice_n)
+
+				outputs = model(inputs)
+
+				if not isinstance(outputs, list):
+					outputs = [outputs]
+
+				# Save all the outputs for 
+				# merging back together later
+				for l in range(len(outputs)):
+					outputs_all[l].append(outputs[l])
+
+	# Merge outputs on CPU
+	with tf.device('/cpu:0'):
+		merged = []
+
+		for outputs in outputs_all:
+			merged.append(merge(outputs, mode='concat', concat_axis=0))
+
+	return Model(input=model.inputs, output=merged)

--- a/kur/utils/parallelism.py
+++ b/kur/utils/parallelism.py
@@ -57,7 +57,7 @@ def make_parallel(model, gpu_count):
 				# Slice each input into a piece 
 				# for processing on this GPU
 				for x in model.inputs:
-					input_shape = tuple(x.get_shape().as_list())[1:]
+					input_shape = (None,) + tuple(x.get_shape().as_list())[1:]
 					slice_n = Lambda(slice_batch, 
 						lambda shape: input_shape, 
 						arguments={'n_gpus':gpu_count, 'part':i})(x)


### PR DESCRIPTION
The "parallel" option in backend specification of the kurfile
is either 1 (single GPU) or > 1 (multi GPU).

Like:
```
backend: &backend
  name: keras
  backend: tensorflow
  parallel: 2
```

Will only work with the tensorflow keras backend.