### PR TITLE
Add CSV output via hooks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": false
+}


### PR DESCRIPTION
Extend and enable CSV output (along with the previously existing pickle output).
This makes it easier to look at raw data and analyze details further.

Based on discussion on gitter from Jan 27