### PR TITLE
Symlink audiotools fix

### DIFF
--- a/kur/utils/audiotools.py
+++ b/kur/utils/audiotools.py
@@ -117,9 +117,12 @@ def get_mime_type(filename):
 		# and try again with the target file.  We do this in 
 		# a while loop to cover the case of symlinks which
 		# point to other symlinks
+		current_filename = filename
 		while ftype == 'inode/symlink':
-			ftype = mime_magic.from_file(os.readlink(filename))
+			current_filename = os.readlink(current_filename)
+			ftype = mime_magic.from_file(current_filename)
 			ftype = ftype.decode('utf-8') if isinstance(ftype, bytes) else ftype
+			
 		return ftype
 
 get_mime_type.warn = True

--- a/kur/utils/audiotools.py
+++ b/kur/utils/audiotools.py
@@ -114,8 +114,10 @@ def get_mime_type(filename):
 			ftype = ftype.decode('utf-8')
 
 		# If we are dealing with a symlink, read the link
-		# and try again with the target file.
-		if ftype == 'inode/symlink':
+		# and try again with the target file.  We do this in 
+		# a while loop to cover the case of symlinks which
+		# point to other symlinks
+		while ftype == 'inode/symlink':
 			ftype = mime_magic.from_file(os.readlink(filename))
 			ftype = ftype.decode('utf-8') if isinstance(ftype, bytes) else ftype
 		return ftype

--- a/kur/utils/audiotools.py
+++ b/kur/utils/audiotools.py
@@ -112,6 +112,12 @@ def get_mime_type(filename):
 		ftype = mime_magic.from_file(filename)
 		if isinstance(ftype, bytes):
 			ftype = ftype.decode('utf-8')
+
+		# If we are dealing with a symlink, read the link
+		# and try again with the target file.
+		if ftype == 'inode/symlink':
+			ftype = mime_magic.from_file(os.readlink(filename))
+			ftype = ftype.decode('utf-8') if isinstance(ftype, bytes) else ftype
 		return ftype
 
 get_mime_type.warn = True


### PR DESCRIPTION
As it is currently written, the get_mime_type method of the audiotools module throws an exception when reading symlinks because it doesn't recognize "inode/symlink" as a valid mime type for audio data, even if the target of the link is a valid format.  

This pull request introduces a fix for the issue that should work for nested symlinks.  