### PR TITLE
Adding code to parallelize the pre-processing of audio data in speech…

### DIFF
--- a/kur/supplier/speechrec.py
+++ b/kur/supplier/speechrec.py
@@ -186,7 +186,8 @@ class RawUtterance(ChunkSource):
 
 		self._init_normalizer(normalization)
 
-		self.data_cpus = data_cpus
+		assert isinstance(data_cpus, int)
+		self.data_cpus = max(1, data_cpus)
 		self.pool = ProcessPoolExecutor(data_cpus)
 
 	###########################################################################
@@ -550,7 +551,7 @@ class SpeechRecognitionSupplier(Supplier):
 		self.downselect(samples)
 
 		logger.debug('Creating sources.')
-		data_cpus = multiprocessing.cpu_count() - 1 if not data_cpus else data_cpus
+		data_cpus = max(1, multiprocessing.cpu_count() - 1 if not data_cpus else data_cpus)
 		utterance_raw = RawUtterance(
 			self.data['audio'],
 			feature_type=type or SpeechRecognitionSupplier.DEFAULT_TYPE,


### PR DESCRIPTION
…rec.py

This is a proposed modification to kur that distributes the work of pre-processing audio data in the speech recognition supplier.  Pre-processing audio data is a computationally expensive task (due to the ffts that are calculated).  When running with multiple GPUs and large batch size, the current configuration (which does all pre-processing on one thread) is insufficient and batch times are compromised as a result.   

The proposed solution simply offloads the computationally expensive function call (get_audio_features) in a worker function that is submitted to a ProcessPoolExecutor from Python's native concurrent.futures module.  The default behavior is to use a pool size of n - 1, where n is the number of CPUs on the system as determined by multiprocessing.cpu_count().  For a variety of reasons, this ansatz may not be optimal, so users have the option of manually specifying the number of processes that should be used for data pre-processing.  This is done with the "data_cpus" option for the speech recognition supplier.

Testing shows that speedups of at least 2x are possible with this approach.