### PR TITLE
Make multiprocessing.pool play nice with SIGINT in speechrec.py

### DIFF
--- a/kur/supplier/speechrec.py
+++ b/kur/supplier/speechrec.py
@@ -42,7 +42,7 @@ def _init_data_worker():
 ###############################################################################
 def _load_single(args):
 	"""
-	This function is called through an instance of ProcessPoolExecutor
+	This function is called through an instance of multiprocessing.Pool 
 	in the RawUtterance source.  We do not make this function an instance
 	method of RawUtterance in order to avoid unnecessary pickling of 
 	RawUtterance instances which would fail due to the presence of some


### PR DESCRIPTION
Currently, the multiprocessing that is used in speechrec.py via a ProcessPoolExecutor doen't work well when a user interrupts Kur during training (using SIGINT).  The problem seems to be due to logic used by ProcessPoolExecutor which wraps multiprocessing.Pool. 

The solution to the problem is to replace concurrent.futures.ProcessPoolExecutor with multiprocessing.Pool.  Some additional logic is added to suppress unnecessary stack traces (those coming from the terminated child processes) from appearing.  